### PR TITLE
os: container template: avoid iproute alias

### DIFF
--- a/os/lib/nixos-container/vpsadminos.nix
+++ b/os/lib/nixos-container/vpsadminos.nix
@@ -53,7 +53,7 @@ in {
     before = [ "network.target" ];
     wantedBy = [ "network.target" ];
     after = [ "network-pre.target" ];
-    path = [ pkgs.iproute ];
+    path = [ pkgs.iproute2 ];
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;


### PR DESCRIPTION
It was renamed in <https://github.com/NixOS/nixpkgs/commit/100061531363d2b780baaedf07588adfad2c2148> and the old name was moved to aliases in <https://github.com/NixOS/nixpkgs/commit/9378fdf87e0626e8c63a90a378c38444ff54808b>.

Using an alias breaks system evaluation with `nixpkgs.config.allowAliases = false`.