### PR TITLE
flake.nix: provide flake with access to the nixos-container nixos module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,8 @@
+{
+  description = "VPS Admin OS flake";
+
+  outputs = { self }: {
+    nixosConfigurations.default = import ./os/lib/nixos-container/vpsadminos.nix;
+  };
+
+}


### PR DESCRIPTION
This allows simple inclusion and update of the vpsadminos configuration to the third-party containers.

The example usage in my repository https://git.cynerd.cz/nixos-personal/tree/flake.nix#n55.