### PR TITLE
docs: update NixOS wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ vpsAdminOS uses:
 
 ## Building OS
 
-Our kernel live-patch facility requires [ccache](https://nixos.wiki/wiki/CCache)
+Our kernel live-patch facility requires [ccache](https://wiki.nixos.org/wiki/CCache)
 to build the OS.
 
 ```bash

--- a/docs/user-guide/setup.md
+++ b/docs/user-guide/setup.md
@@ -48,7 +48,7 @@ When you have at least one zpool imported and installed, you can proceed
 to [container](containers.md) management.
 
 [Nix]: https://nixos.org/nix/
-[ccache]: https://nixos.wiki/wiki/CCache
+[ccache]: https://wiki.nixos.org/wiki/CCache
 [install-nix]: https://nixos.org/nix/download.html
 [nixpkgs]: https://nixos.org/nixpkgs/
 [man osctl]: https://man.vpsadminos.org/man8/osctl.8.html


### PR DESCRIPTION
Hi!

This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113