### PR TITLE
improve speed of netboot build

### DIFF
--- a/os/lib/make-squashfs.nix
+++ b/os/lib/make-squashfs.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
       # Generate the squashfs image.
       mksquashfs nix-path-registration $(cat $closureInfo/store-paths) \
         ${lib.optionalString (secretsDir != null) secretsDir} \
-        $out -keep-as-directory -all-root -b 1048576 -comp zstd -Xcompression-level 3
+        $out -keep-as-directory -all-root -b 1048576 -comp zstd
     '';
 }

--- a/os/lib/make-squashfs.nix
+++ b/os/lib/make-squashfs.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
       # Generate the squashfs image.
       mksquashfs nix-path-registration $(cat $closureInfo/store-paths) \
         ${lib.optionalString (secretsDir != null) secretsDir} \
-        $out -keep-as-directory -all-root -b 1048576 -comp xz -Xdict-size 100%
+        $out -keep-as-directory -all-root -b 1048576 -comp zstd -Xcompression-level 3
     '';
 }

--- a/os/lib/make-squashfs.nix
+++ b/os/lib/make-squashfs.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
       # Generate the squashfs image.
       mksquashfs nix-path-registration $(cat $closureInfo/store-paths) \
         ${lib.optionalString (secretsDir != null) secretsDir} \
-        $out -keep-as-directory -all-root -b 1048576 -comp zstd
+        $out -keep-as-directory -all-root -b 1048576 -comp zstd -Xcompression-level 7
     '';
 }


### PR DESCRIPTION
hi there, i'm a big fan of the work you're doing on vpsAdminOS! i'm trying to build a modest datacenter installation (order ~100 cores, disks, and users) and vpsfree.cz is really inspiring!

in the process of setting up my hosts, i was intent on pxe booting and i noticed during (the many, many) rebuilds that it was taking a long time and using only one core. i'd love to speed this up, so started to try to find out what i could do to help that and found my way to the mksquashfs call.

i'm sure this is incomplete/needs more work, but i wanted to at least share where i'm at to see if this is an area i should work on before i spend more time digging in. (also, it's been several months since i was deep in it due to life stuff, so my context here is a little outdated)

any pointers/guidance/re-orientation is welcome! cheers!