### PR TITLE
os/unstable: Update resolved option name

### DIFF
--- a/os/lib/nixos-container/unstable/vpsadminos.nix
+++ b/os/lib/nixos-container/unstable/vpsadminos.nix
@@ -28,7 +28,7 @@ let
 in
 {
   networking.nameservers = mkDefault nameservers;
-  services.resolved = mkDefault { fallbackDns = nameservers; };
+  services.resolved.settings.Resolve = mkDefault { FallbackDNS = nameservers; };
   networking.dhcpcd.extraConfig = "noipv4ll";
 
   systemd.services.systemd-oomd.enable = false;


### PR DESCRIPTION
It was switched to RFC 42 style in https://github.com/NixOS/nixpkgs/commit/ab385083dca84eedba7e44dc570809cb6a05754c
