### PR TITLE
crashdump: prioritize essential inspection

### DIFF
--- a/os/modules/misc/crashdump.nix
+++ b/os/modules/misc/crashdump.nix
@@ -215,111 +215,169 @@ in
             #!/bin/sh
             set -u
 
+            profile=essential
+
+            case "''${1:-}" in
+              --full)
+                profile=full
+                shift
+                ;;
+              -h|--help)
+                echo "usage: crash-collect [--full] [OUTDIR]"
+                exit 0
+                ;;
+              -*)
+                echo "crash-collect: unknown option: $1" >&2
+                exit 2
+                ;;
+            esac
+
+            if [ "$#" -gt 1 ] ; then
+              echo "usage: crash-collect [--full] [OUTDIR]" >&2
+              exit 2
+            fi
+
             outdir=''${1:-/tmp/crash-inspect}
-            tmpdir=$(mktemp -d /tmp/crash-collect.XXXXXX)
-            status=0
+            tmpdir=$(mktemp -d /tmp/crash-collect.XXXXXX) || exit 1
+            overall_status=0
             trap 'rm -rf "$tmpdir"' EXIT
 
-            mkdir -p "$outdir"
-            : > "$outdir/status"
+            mkdir -p "$outdir" || exit 1
+            outdir=$(cd "$outdir" && pwd -P) || exit 1
 
             cat > "$outdir/README" <<'EOF_COLLECT_README'
-            Files written by crash-collect:
+            Usage: crash-collect [--full] [OUTDIR]
+
+            The default essential profile prioritizes evidence needed to
+            diagnose the panic and active CPUs. The --full profile appends
+            expensive whole-task-table reports after essential collection.
+
+            Files written by both profiles:
               manifest                        basic metadata about the collected vmcore
-              status                          exit status of each crash command
+              status                          collection and output status
+              timings                         start, end and duration of each report
+              session.log                     crash(8) initialization and command log
               sys.txt                         sys, sys -t, kmem -i
               log.txt                         log -m
-              ps.txt                          ps
               ps-summary.txt                  ps -S
+              tasks.txt                       lightweight task identity and state inventory
+              bt-panic.txt                    bt -p
+              bt-active.txt                   bt -a -n idle
+              bt-sleeping-uninterruptible.txt foreach UN bt
+
+            Additional files written by --full:
+              ps.txt                          ps
               ps-last-run.txt                 ps -m
               ps-active.txt                   ps -A
-              bt-panic.txt                    bt -p
-              bt-active.txt                   bt -a
-              bt-active-nonidle.txt           bt -a -n idle
               bt-sleeping-interruptible.txt   foreach IN bt
-              bt-sleeping-uninterruptible.txt foreach UN bt
             EOF_COLLECT_README
 
             cat > "$outdir/manifest" <<EOF_COLLECT_MANIFEST
             vmlinux=''${CRASH_VMLINUX:-/.crash/vmlinux.gz}
             vmcore=/proc/vmcore
             crash_binary=$(readlink -f "$(command -v crash)")
+            profile=$profile
             EOF_COLLECT_MANIFEST
 
-            run_crash() {
-              local name rc cmdfile
-              name="$1"
-              cmdfile="$tmpdir/$1.cmd"
-              cat > "$cmdfile"
-              echo "crash-collect: $name"
-              if crash-vmcore -i "$cmdfile" > "$outdir/$name" 2>&1 ; then
-                rc=0
+            cmdfile="$tmpdir/collect.cmd"
+            cat > "$cmdfile" <<'EOF_CRASH_ESSENTIAL'
+            !date +%s > .sys.txt.start
+            sys > sys.txt
+            sys -t >> sys.txt
+            kmem -i >> sys.txt
+            !date +%s > .sys.txt.end
+
+            !date +%s > .log.txt.start
+            log -m > log.txt
+            !date +%s > .log.txt.end
+
+            !date +%s > .bt-panic.txt.start
+            bt -p > bt-panic.txt
+            !date +%s > .bt-panic.txt.end
+
+            !date +%s > .bt-active.txt.start
+            bt -a -n idle > bt-active.txt
+            !date +%s > .bt-active.txt.end
+
+            !date +%s > .bt-sleeping-uninterruptible.txt.start
+            foreach UN bt > bt-sleeping-uninterruptible.txt
+            !date +%s > .bt-sleeping-uninterruptible.txt.end
+
+            !date +%s > .ps-summary.txt.start
+            ps -S > ps-summary.txt
+            !date +%s > .ps-summary.txt.end
+
+            !date +%s > .tasks.txt.start
+            foreach task -R __state,real_parent > tasks.txt
+            !date +%s > .tasks.txt.end
+            EOF_CRASH_ESSENTIAL
+
+            reports="sys.txt log.txt bt-panic.txt bt-active.txt bt-sleeping-uninterruptible.txt ps-summary.txt tasks.txt"
+
+            if [ "$profile" = full ] ; then
+              cat >> "$cmdfile" <<'EOF_CRASH_FULL'
+
+            !date +%s > .ps.txt.start
+            ps > ps.txt
+            !date +%s > .ps.txt.end
+
+            !date +%s > .ps-last-run.txt.start
+            ps -m > ps-last-run.txt
+            !date +%s > .ps-last-run.txt.end
+
+            !date +%s > .ps-active.txt.start
+            ps -A > ps-active.txt
+            !date +%s > .ps-active.txt.end
+
+            !date +%s > .bt-sleeping-interruptible.txt.start
+            foreach IN bt > bt-sleeping-interruptible.txt
+            !date +%s > .bt-sleeping-interruptible.txt.end
+            EOF_CRASH_FULL
+
+              reports="$reports ps.txt ps-last-run.txt ps-active.txt bt-sleeping-interruptible.txt"
+            fi
+
+            echo quit >> "$cmdfile"
+
+            echo "crash-collect: profile $profile"
+            session_start=$(date +%s)
+            if (cd "$outdir" && crash-vmcore -i "$cmdfile") > "$outdir/session.log" 2>&1 ; then
+              session_rc=0
+            else
+              session_rc=$?
+              overall_status=1
+            fi
+            session_end=$(date +%s)
+
+            : > "$outdir/status"
+            echo "session $session_rc" >> "$outdir/status"
+
+            : > "$outdir/timings"
+            echo "session start=$session_start end=$session_end duration=$((session_end - session_start))s" \
+              >> "$outdir/timings"
+
+            for name in $reports ; do
+              if [ -s "$outdir/$name" ] ; then
+                echo "$name 0" >> "$outdir/status"
               else
-                rc=$?
-                status=1
+                echo "$name 1" >> "$outdir/status"
+                overall_status=1
               fi
-              echo "$name $rc" >> "$outdir/status"
-              return 0
-            }
 
-            run_crash sys.txt <<'EOF_CRASH_SYS'
-            sys
-            sys -t
-            kmem -i
-            quit
-            EOF_CRASH_SYS
+              if [ -s "$outdir/.$name.start" ] && [ -s "$outdir/.$name.end" ] ; then
+                start=$(cat "$outdir/.$name.start")
+                end=$(cat "$outdir/.$name.end")
+                echo "$name start=$start end=$end duration=$((end - start))s" \
+                  >> "$outdir/timings"
+              else
+                echo "$name timing=incomplete" >> "$outdir/timings"
+                overall_status=1
+              fi
 
-            run_crash log.txt <<'EOF_CRASH_LOG'
-            log -m
-            quit
-            EOF_CRASH_LOG
+              rm -f "$outdir/.$name.start" "$outdir/.$name.end"
+            done
 
-            run_crash ps.txt <<'EOF_CRASH_PS'
-            ps
-            quit
-            EOF_CRASH_PS
-
-            run_crash ps-summary.txt <<'EOF_CRASH_PS_SUMMARY'
-            ps -S
-            quit
-            EOF_CRASH_PS_SUMMARY
-
-            run_crash ps-last-run.txt <<'EOF_CRASH_PS_LAST_RUN'
-            ps -m
-            quit
-            EOF_CRASH_PS_LAST_RUN
-
-            run_crash ps-active.txt <<'EOF_CRASH_PS_ACTIVE'
-            ps -A
-            quit
-            EOF_CRASH_PS_ACTIVE
-
-            run_crash bt-panic.txt <<'EOF_CRASH_BT_PANIC'
-            bt -p
-            quit
-            EOF_CRASH_BT_PANIC
-
-            run_crash bt-active.txt <<'EOF_CRASH_BT_ACTIVE'
-            bt -a
-            quit
-            EOF_CRASH_BT_ACTIVE
-
-            run_crash bt-active-nonidle.txt <<'EOF_CRASH_BT_ACTIVE_NONIDLE'
-            bt -a -n idle
-            quit
-            EOF_CRASH_BT_ACTIVE_NONIDLE
-
-            run_crash bt-sleeping-interruptible.txt <<'EOF_CRASH_BT_SLEEPING_INTERRUPTIBLE'
-            foreach IN bt
-            quit
-            EOF_CRASH_BT_SLEEPING_INTERRUPTIBLE
-
-            run_crash bt-sleeping-uninterruptible.txt <<'EOF_CRASH_BT_SLEEPING_UNINTERRUPTIBLE'
-            foreach UN bt
-            quit
-            EOF_CRASH_BT_SLEEPING_UNINTERRUPTIBLE
-
-            exit $status
+            exit $overall_status
             EOF_CRASH_COLLECT
             chmod +x $out/bin/crash-collect
           ''}

--- a/tests/suite/crashdump/inspect.nix
+++ b/tests/suite/crashdump/inspect.nix
@@ -28,8 +28,8 @@ import ../../make-test.nix (
                 echo "/proc/vmcore is missing"
               fi
 
-              echo "Running crash-collect"
-              crash-collect inspect
+              echo "Running crash-collect --full"
+              crash-collect --full inspect
               rc=$?
               echo "crash-collect exited with $rc"
 
@@ -39,6 +39,8 @@ import ../../make-test.nix (
                 inspect/README \
                 inspect/manifest \
                 inspect/status \
+                inspect/timings \
+                inspect/tasks.txt \
                 inspect/ps-active.txt \
                 inspect/bt-active.txt \
                 inspect/bt-sleeping-interruptible.txt \
@@ -47,9 +49,21 @@ import ../../make-test.nix (
                   echo "=== $f ==="
                   sed -n '1,80p' "$f"
                 else
-                  echo "$f is missing"
+                  fail "$f is missing"
                 fi
               done
+
+              grep -F 'profile=full' inspect/manifest \
+                || fail "Full profile is not recorded in the manifest"
+              grep -F 'session 0' inspect/status \
+                || fail "The consolidated crash session failed"
+              grep -F 'tasks.txt 0' inspect/status \
+                || fail "The lightweight task inventory failed"
+              grep -F 'ps-active.txt 0' inspect/status \
+                || fail "The full profile active-task report failed"
+              grep -E '^session start=[0-9]+ end=[0-9]+ duration=[0-9]+s$' inspect/timings \
+                || fail "The consolidated session timing is missing"
+              echo "Full crash inspection profile verified"
 
               echo "Dumping dmesg"
               makedumpfile --dump-dmesg /proc/vmcore dmesg.log
@@ -168,13 +182,16 @@ import ../../make-test.nix (
             machine.wait_for_console_text(/sysrq: Trigger a crash/, timeout:)
             machine.wait_for_console_text(/Kernel panic - not syncing: sysrq triggered crash/, timeout:)
             machine.wait_for_console_text(/This is a crash kernel/, timeout:)
-            machine.wait_for_console_text(/Running crash-collect/, timeout:)
+            machine.wait_for_console_text(/Running crash-collect --full/, timeout:)
             machine.wait_for_console_text(/crash-collect exited with 0/, timeout:)
             machine.wait_for_console_text(/inspect\/README/, timeout:)
+            machine.wait_for_console_text(/inspect\/timings/, timeout:)
+            machine.wait_for_console_text(/inspect\/tasks.txt/, timeout:)
             machine.wait_for_console_text(/inspect\/ps-active.txt/, timeout:)
             machine.wait_for_console_text(/inspect\/bt-active.txt/, timeout:)
             machine.wait_for_console_text(/inspect\/bt-sleeping-interruptible.txt/, timeout:)
             machine.wait_for_console_text(/inspect\/bt-sleeping-uninterruptible.txt/, timeout:)
+            machine.wait_for_console_text(/Full crash inspection profile verified/, timeout:)
             machine.wait_for_console_text(/Dumping dmesg/, timeout:)
             machine.wait_for_console_text(/#{Regexp.escape(message)}/, timeout:)
           end

--- a/tests/suite/crashdump/nfs-inspect.nix
+++ b/tests/suite/crashdump/nfs-inspect.nix
@@ -204,7 +204,8 @@ import ../../make-test.nix (
           test -f "$target/inspect.exit-status"
           test -f "$target/inspect/status"
           test -f "$target/inspect/manifest"
-          test -f "$target/inspect/ps-active.txt"
+          test -f "$target/inspect/timings"
+          test -f "$target/inspect/tasks.txt"
           test -f "$target/inspect/bt-active.txt"
         CMD
       end
@@ -278,8 +279,15 @@ import ../../make-test.nix (
 
             server.succeeds("grep -F #{Shellwords.escape(message)} #{Shellwords.escape(target)}/dmesg")
             server.succeeds("grep -F 'vmcore=/proc/vmcore' #{Shellwords.escape(target)}/inspect/manifest")
-            server.succeeds("grep -F 'ps-active.txt 0' #{Shellwords.escape(target)}/inspect/status")
+            server.succeeds("grep -F 'profile=essential' #{Shellwords.escape(target)}/inspect/manifest")
+            server.succeeds("grep -F 'session 0' #{Shellwords.escape(target)}/inspect/status")
+            server.succeeds("grep -F 'tasks.txt 0' #{Shellwords.escape(target)}/inspect/status")
             server.succeeds("grep -F 'bt-active.txt 0' #{Shellwords.escape(target)}/inspect/status")
+            server.succeeds("grep -E '^session start=[0-9]+ end=[0-9]+ duration=[0-9]+s$' #{Shellwords.escape(target)}/inspect/timings")
+            server.fails("test -e #{Shellwords.escape(target)}/inspect/ps.txt")
+            server.fails("test -e #{Shellwords.escape(target)}/inspect/ps-active.txt")
+            server.fails("test -e #{Shellwords.escape(target)}/inspect/ps-last-run.txt")
+            server.fails("test -e #{Shellwords.escape(target)}/inspect/bt-sleeping-interruptible.txt")
           end
         end
       end


### PR DESCRIPTION
## Summary

- run crash inspection reports in one crash session
- collect panic and active-CPU evidence before broad task-table diagnostics
- keep expensive reports behind an explicit full profile
- record report status and timings and cover both local and NFS-backed collection

## Validation

- Nix parse and formatting checks
- generated shell syntax and help checks
- Overcommit Nixfmt and RuboCop hooks
- focused local and NFS crashdump tests: 12 examples passed
- complete CI run 32843565061: OS build, full test suite, AMD lifecycle, and Intel lifecycle passed